### PR TITLE
aplica charset na conexão HTTP

### DIFF
--- a/source/Services/Checkout/Payment.php
+++ b/source/Services/Checkout/Payment.php
@@ -62,7 +62,9 @@ class Payment
             );
             $http->post(
                 self::request($connection),
-                \PagSeguro\Parsers\Checkout\Request::getData($payment)
+                \PagSeguro\Parsers\Checkout\Request::getData($payment),
+                20,
+                \PagSeguro\Configuration\Configure::getCharset()->getEncoding()
             );
 
             $response = Responsibility::http(


### PR DESCRIPTION
existe configuração de charset (UTF-8 ou ISO-8859-1) mas, ao estabelecer uma conexão, a classe não estava passando o charset da config para função `$http->post()` ficando assim com o charset padrão (ISO)