### PR TITLE
Fix bug when using installment with credit card direct payment

### DIFF
--- a/source/Domains/DirectPayment/CreditCard/Installment.php
+++ b/source/Domains/DirectPayment/CreditCard/Installment.php
@@ -33,7 +33,8 @@ class Installment
 {
     private $quantity;
     private $value;
-    
+    private $noInterestInstallmentQuantity;
+
     public function getQuantity()
     {
         return $this->quantity;
@@ -42,6 +43,11 @@ class Installment
     public function getValue()
     {
         return $this->value;
+    }
+
+    public function getNoInterestInstallmentQuantity()
+    {
+        return $this->noInterestInstallmentQuantity;
     }
 
     public function setQuantity($quantity)
@@ -53,6 +59,12 @@ class Installment
     public function setValue($value)
     {
         $this->value = $value;
+        return $this;
+    }
+
+    public function setNoInterestInstallmentQuantity($noInterestQuantity)
+    {
+        $this->noInterestInstallmentQuantity = $noInterestQuantity;
         return $this;
     }
 }

--- a/source/Enum/Properties/BackwardCompatibility.php
+++ b/source/Enum/Properties/BackwardCompatibility.php
@@ -144,7 +144,7 @@ class BackwardCompatibility
     /**
      * Installment no interest installment quantity for credit card payment
      */
-    const INSTALLMENT_NO_INTEREST_INSTALLMENT_QUANTITY = "installment.noInterestInstallmentQuantity=";
+    const INSTALLMENT_NO_INTEREST_INSTALLMENT_QUANTITY = "installment.noInterestInstallmentQuantity";
 
     /**
      *  Item id

--- a/source/Parsers/DirectPayment/CreditCard/Installment.php
+++ b/source/Parsers/DirectPayment/CreditCard/Installment.php
@@ -51,6 +51,10 @@ trait Installment
         if (!is_null($installment->getValue())) {
             $data[$properties::INSTALLMENT_VALUE] = Currency::toDecimal($installment->getValue());
         }
+        // setNoInterestInstallmentQuantity
+        if (!is_null($installment->getNoInterestInstallmentQuantity())) {
+            $data[$properties::INSTALLMENT_NO_INTEREST_INSTALLMENT_QUANTITY] = Currency::toDecimal($installment->getNoInterestInstallmentQuantity());
+        }
 
         return $data;
     }

--- a/source/Resources/Factory/Request/DirectPayment/CreditCard/Installment.php
+++ b/source/Resources/Factory/Request/DirectPayment/CreditCard/Installment.php
@@ -33,15 +33,24 @@ class Installment
         $installment->setQuantity($array['quantity'])
             ->setValue($array['value']);
 
+        if (isset($array['no_interest_installment_quantity'])) {
+            $installment->setNoInterestInstallmentQuantity($array['no_interest_installment_quantity']);
+        }
+
         $this->installment = $installment;
         return $this->installment;
     }
     
-    public function withParameters($quantity, $value)
+    public function withParameters($quantity, $value, $noInterestInstallmentQuantity = null)
     {
         $installment = new \PagSeguro\Domains\DirectPayment\CreditCard\Installment();
         $installment->setQuantity($quantity)
             ->setValue($value);
+
+        if ($noInterestInstallmentQuantity) {
+            $installment->setNoInterestInstallmentQuantity($noInterestInstallmentQuantity);
+        }
+
         $this->installment = $installment;
 
         return $this->installment;


### PR DESCRIPTION
Quando usava o parcelamento de cartão de crédito através de Direct Payment, sempre me era retornado a seguinte exceção:
53041: installment value invalid value: (Valor)
Verificando os logs e a documentação da API, eu constatei que na requisição não estava sendo passado a variável "noInterestInstallmentQuantity".
O que fiz, foram alterações necessárias para que essa variável pudesse ser enviada.
A partir dessas alterações tudo passou a funcionar.