### PR TITLE
Update Response.php

### DIFF
--- a/source/Parsers/Transaction/Search/Date/Response.php
+++ b/source/Parsers/Transaction/Search/Date/Response.php
@@ -179,6 +179,7 @@ class Response
             ->setPaymentMethod($response->paymentMethod)
             ->setGrossAmount(current($response->grossAmount))
             ->setDiscountAmount(current($response->discountAmount))
+            ->setFeeAmount(current($response->feeAmount))
             ->setNetAmount(current($response->netAmount))
             ->setExtraAmount(current($response->extraAmount))
             ->setCancellationSource(current($response->cancellationSource));


### PR DESCRIPTION
Estava faltando definir a taxa cobrada na transação.
Caso não seja definido, a aplicação que realiza a integração terá subtrair o bruto pelo líquido para chegar na taxa.