### PR TITLE
Fix #27 - Casting bool to string generate incorrect URL

### DIFF
--- a/source/Services/Application/Search/Date.php
+++ b/source/Services/Application/Search/Date.php
@@ -97,10 +97,10 @@ class Date
             $connection->buildAuthorizationSearchRequestUrl(),
             $connection->buildCredentialsQuery(),
             sprintf("&%s=%s", Current::SEARCH_INITIAL_DATE, $params["initial_date"]),
-            !isset($params["final_date"]) ?: sprintf("&%s=%s", Current::SEARCH_FINAL_DATE, $params["final_date"]),
-            !isset($params["max_per_page"]) ?:
+            !isset($params["final_date"]) ? '' : sprintf("&%s=%s", Current::SEARCH_FINAL_DATE, $params["final_date"]),
+            !isset($params["max_per_page"]) ? '' :
                 sprintf("&%s=%s", Current::SEARCH_MAX_RESULTS_PER_PAGE, $params["max_per_page"]),
-            !isset($params["page"]) ?: sprintf("&%s=%s", Current::SEARCH_PAGE, $params["page"])
+            !isset($params["page"]) ? '' : sprintf("&%s=%s", Current::SEARCH_PAGE, $params["page"])
         );
     }
 }

--- a/source/Services/Application/Search/Reference.php
+++ b/source/Services/Application/Search/Reference.php
@@ -100,10 +100,10 @@ class Reference
             $connection->buildCredentialsQuery(),
             $reference,
             sprintf("&%s=%s", Current::SEARCH_INITIAL_DATE, $params["initial_date"]),
-            !isset($params["final_date"]) ?: sprintf("&%s=%s", Current::SEARCH_FINAL_DATE, $params["final_date"]),
-            !isset($params["max_per_page"]) ?:
+            !isset($params["final_date"]) ? '' : sprintf("&%s=%s", Current::SEARCH_FINAL_DATE, $params["final_date"]),
+            !isset($params["max_per_page"]) ? '' :
                 sprintf("&%s=%s", Current::SEARCH_MAX_RESULTS_PER_PAGE, $params["max_per_page"]),
-            !isset($params["page"]) ?: sprintf("&%s=%s", Current::SEARCH_PAGE, $params["page"])
+            !isset($params["page"]) ? '' : sprintf("&%s=%s", Current::SEARCH_PAGE, $params["page"])
         );
     }
 }

--- a/source/Services/Installment.php
+++ b/source/Services/Installment.php
@@ -63,7 +63,7 @@ class Installment
             $connection->buildInstallmentRequestUrl(),
             $connection->buildCredentialsQuery(),
             sprintf("&%s=%s", Current::INSTALLMENT_AMOUNT, Currency::toDecimal($params['amount'])),
-            is_null($params['card_brand']) ?:
+            is_null($params['card_brand']) ? '' :
                 sprintf("&%s=%s", Current::INSTALLMENT_CARD_BRAND, $params['card_brand']),
             is_null($params['max_installment_no_interest']) ? '' :
                 sprintf(

--- a/source/Services/PreApproval/Search/Date.php
+++ b/source/Services/PreApproval/Search/Date.php
@@ -94,10 +94,10 @@ class Date
             $connection->buildPreApprovalSearchRequestUrl(),
             $connection->buildCredentialsQuery(),
             sprintf("&%s=%s", Current::SEARCH_INITIAL_DATE, $params["initial_date"]),
-            !isset($params["final_date"]) ?: sprintf("&%s=%s", Current::SEARCH_FINAL_DATE, $params["final_date"]),
-            !isset($params["max_per_page"]) ?:
+            !isset($params["final_date"]) ? '' : sprintf("&%s=%s", Current::SEARCH_FINAL_DATE, $params["final_date"]),
+            !isset($params["max_per_page"]) ? '' :
                 sprintf("&%s=%s", Current::SEARCH_MAX_RESULTS_PER_PAGE, $params["max_per_page"]),
-            !isset($params["page"]) ?: sprintf("&%s=%s", Current::SEARCH_PAGE, $params["page"])
+            !isset($params["page"]) ? '' : sprintf("&%s=%s", Current::SEARCH_PAGE, $params["page"])
         );
     }
 }

--- a/source/Services/Transactions/Search/Abandoned.php
+++ b/source/Services/Transactions/Search/Abandoned.php
@@ -97,10 +97,10 @@ class Abandoned
             $connection->buildAbandonedRequestUrl(),
             $connection->buildCredentialsQuery(),
             sprintf("&%s=%s", Current::SEARCH_INITIAL_DATE, $params["initial_date"]),
-            !isset($params["final_date"]) ?: sprintf("&%s=%s", Current::SEARCH_FINAL_DATE, $params["final_date"]),
-            !isset($params["max_per_page"]) ?:
+            !isset($params["final_date"]) ? '' : sprintf("&%s=%s", Current::SEARCH_FINAL_DATE, $params["final_date"]),
+            !isset($params["max_per_page"]) ? '' :
                 sprintf("&%s=%s", Current::SEARCH_MAX_RESULTS_PER_PAGE, $params["max_per_page"]),
-            !isset($params["page"]) ?: sprintf("&%s=%s", Current::SEARCH_PAGE, $params["page"])
+            !isset($params["page"]) ? '' : sprintf("&%s=%s", Current::SEARCH_PAGE, $params["page"])
         );
     }
 }

--- a/source/Services/Transactions/Search/Date.php
+++ b/source/Services/Transactions/Search/Date.php
@@ -97,10 +97,10 @@ class Date
             $connection->buildTransactionSearchRequestUrl(),
             $connection->buildCredentialsQuery(),
             sprintf("&%s=%s", Current::SEARCH_INITIAL_DATE, $params["initial_date"]),
-            !isset($params["final_date"]) ?: sprintf("&%s=%s", Current::SEARCH_FINAL_DATE, $params["final_date"]),
-            !isset($params["max_per_page"]) ?:
+            !isset($params["final_date"]) ? '' : sprintf("&%s=%s", Current::SEARCH_FINAL_DATE, $params["final_date"]),
+            !isset($params["max_per_page"]) ? '' :
                 sprintf("&%s=%s", Current::SEARCH_MAX_RESULTS_PER_PAGE, $params["max_per_page"]),
-            !isset($params["page"]) ?: sprintf("&%s=%s", Current::SEARCH_PAGE, $params["page"])
+            !isset($params["page"]) ? '' : sprintf("&%s=%s", Current::SEARCH_PAGE, $params["page"])
         );
     }
 }

--- a/source/Services/Transactions/Search/Reference.php
+++ b/source/Services/Transactions/Search/Reference.php
@@ -104,10 +104,10 @@ class Reference
             $connection->buildCredentialsQuery(),
             $reference,
             sprintf("&%s=%s", Current::SEARCH_INITIAL_DATE, $params["initial_date"]),
-            !isset($params["final_date"]) ?: sprintf("&%s=%s", Current::SEARCH_FINAL_DATE, $params["final_date"]),
-            !isset($params["max_per_page"]) ?:
+            !isset($params["final_date"]) ? '' : sprintf("&%s=%s", Current::SEARCH_FINAL_DATE, $params["final_date"]),
+            !isset($params["max_per_page"]) ? '' :
                 sprintf("&%s=%s", Current::SEARCH_MAX_RESULTS_PER_PAGE, $params["max_per_page"]),
-            !isset($params["page"]) ?: sprintf("&%s=%s", Current::SEARCH_PAGE, $params["page"])
+            !isset($params["page"]) ? '' : sprintf("&%s=%s", Current::SEARCH_PAGE, $params["page"])
         );
     }
 }


### PR DESCRIPTION
Corrigindo #27.

Sobrou um tempo e eu fiz direto pela interface do Github. É a primeira vez que eu uso isso e faço um fork/pull request, então perdão se eu fiz algo errado.

Eu simplesmente troquei todas as ocorrências de ```?:``` por ```? '' :``` , como eu verifiquei que todas eram retornos de URL montadas com o ```sprintf```.

Uma ideia seria usar a função ```http_build_query``` .