### PR TITLE
HSBC Bank Removal

### DIFF
--- a/source/Enum/PaymentMethod/Name.php
+++ b/source/Enum/PaymentMethod/Name.php
@@ -60,11 +60,6 @@ class Name
     const DEBITO_BANRISUL = "DEBITO_BANRISUL";
 
     /**
-     * Débito HSBC
-     */
-    const DEBITO_HSBC = "DEBITO_HSBC";
-
-    /**
      * Boleto
      */
     const BOLETO = "BOLETO";


### PR DESCRIPTION
HSBC ceased to exist in Brazil, now it is Bradesco.