### PR TITLE
Updating Direct Payment endpoint and creating register methods for Split Payment

### DIFF
--- a/public/Split/usingBoleto.php
+++ b/public/Split/usingBoleto.php
@@ -102,7 +102,7 @@ $boleto->setSplit()->addReceiver()->withParameters(
 
 try {
     //Get the crendentials and register the boleto payment
-    $result = $boleto->register(
+    $result = $boleto->registerWithSplit(
         \PagSeguro\Configuration\Configure::getApplicationCredentials()
     );
 

--- a/public/Split/usingCreditCard.php
+++ b/public/Split/usingCreditCard.php
@@ -139,7 +139,7 @@ $creditCard->setSplit()->addReceiver()->withParameters(
 
 try {
     //Get the crendentials and register the boleto payment
-    $result = $creditCard->register(
+    $result = $creditCard->registerWithSplit(
         \PagSeguro\Configuration\Configure::getApplicationCredentials()
     );
     echo "<pre>";

--- a/public/Split/usingInternationalCreditCard.php
+++ b/public/Split/usingInternationalCreditCard.php
@@ -102,7 +102,7 @@ $internationalCreditCard->setSplit()->addReceiver()->withParameters(
 
 try {
     //Get the crendentials and register the boleto payment
-    $result = $internationalCreditCard->register(
+    $result = $internationalCreditCard->registerWithSplit(
         \PagSeguro\Configuration\Configure::getApplicationCredentials()
     );
     echo "<pre>";

--- a/public/Split/usingOnlineDebit.php
+++ b/public/Split/usingOnlineDebit.php
@@ -112,7 +112,7 @@ $onlineDebit->setSplit()->addReceiver()->withParameters(
 
 try {
     //Get the crendentials and register the boleto payment
-    $result = $onlineDebit->register(
+    $result = $onlineDebit->registerWithSplit(
         \PagSeguro\Configuration\Configure::getApplicationCredentials()
     );
 

--- a/source/Configuration/Properties/Resources.xml
+++ b/source/Configuration/Properties/Resources.xml
@@ -95,12 +95,11 @@
                 <request>v2/pre-approvals</request>
             </search>
         </preApproval>
-        <!-- 
-           Nós não utilizamos a V2 deste serviço pois utilizamos uma versão mais recente da API que suporta Split Payment. 
-           Para maiores informações e consultar a disponibilidade de utilização do Split Payment, entre em contato com o PagSeguro. 
-        -->
         <directPayment>
-            <request>transactions/</request>
+            <request>v2/transactions/</request>
         </directPayment>
+        <directPaymentWithSplit>
+            <request>transactions/</request>
+        </directPaymentWithSplit>
     </services>
 </Resources>

--- a/source/Domains/Requests/DirectPayment/CreditCard.php
+++ b/source/Domains/Requests/DirectPayment/CreditCard.php
@@ -41,4 +41,14 @@ class CreditCard extends Request
     {
         return \PagSeguro\Services\DirectPayment\CreditCard::checkout($credentials, $this);
     }
+    
+    /**
+     * @param $credentials
+     * @return string
+     * @throws \Exception
+     */
+    public function registerWithSplit($credentials)
+    {
+        return \PagSeguro\Services\DirectPayment\CreditCard::checkoutWithSplit($credentials, $this);
+    }
 }

--- a/source/Domains/Requests/DirectPayment/InternationalCreditCard.php
+++ b/source/Domains/Requests/DirectPayment/InternationalCreditCard.php
@@ -42,4 +42,15 @@ class InternationalCreditCard extends Request
     {
         return \PagSeguro\Services\DirectPayment\InternationalCreditCard::checkout($credentials, $this);
     }
+    
+    /**
+     * Register a checkout using international credit card
+     * @param $credentials
+     * @return mixed
+     * @throws \Exception
+     */
+    public function registerWithSplit($credentials)
+    {
+        return \PagSeguro\Services\DirectPayment\InternationalCreditCard::checkoutWithSplit($credentials, $this);
+    }
 }

--- a/source/Domains/Requests/DirectPayment/OnlineDebit.php
+++ b/source/Domains/Requests/DirectPayment/OnlineDebit.php
@@ -64,4 +64,14 @@ class OnlineDebit extends Request
     {
         return \PagSeguro\Services\DirectPayment\OnlineDebit::checkout($credentials, $this);
     }
+
+    /**
+     * @param $credentials
+     * @return string
+     * @throws \Exception
+     */
+    public function registerWithSplit($credentials)
+    {
+        return \PagSeguro\Services\DirectPayment\OnlineDebit::checkoutWithSplit($credentials, $this);
+    }
 }

--- a/source/Enum/PaymentMethod/Name.php
+++ b/source/Enum/PaymentMethod/Name.php
@@ -26,10 +26,6 @@ namespace PagSeguro\Enum\PaymentMethod;
 
 /**
  * Class Name
- * @package PagSeguro\Enum\PaymentMethod\Config
- */
-/**
- * Class Name
  * @package PagSeguro\Enum\PaymentMethod
  */
 class Name
@@ -58,11 +54,6 @@ class Name
      * Débito Barisul
      */
     const DEBITO_BANRISUL = "DEBITO_BANRISUL";
-
-    /**
-     * Débito HSBC
-     */
-    const DEBITO_HSBC = "DEBITO_HSBC";
 
     /**
      * Boleto

--- a/source/Parsers/DirectPayment/Boleto/Request.php
+++ b/source/Parsers/DirectPayment/Boleto/Request.php
@@ -29,7 +29,7 @@ namespace PagSeguro\Parsers\DirectPayment\Boleto;
  *
  * @package PagSeguro\Parsers\DirectPayment\Boleto
  */
-use PagSeguro\Enum\Properties\BackwardCompatibility;
+use PagSeguro\Enum\Properties\Current;
 use PagSeguro\Parsers\Basic;
 use PagSeguro\Parsers\Currency;
 use PagSeguro\Parsers\DirectPayment\Mode;
@@ -39,7 +39,6 @@ use PagSeguro\Parsers\Parser;
 use PagSeguro\Parsers\ReceiverEmail;
 use PagSeguro\Parsers\Sender;
 use PagSeguro\Parsers\Shipping;
-use PagSeguro\Parsers\Split;
 use PagSeguro\Resources\Http;
 use PagSeguro\Parsers\Transaction\Boleto\Response;
 
@@ -66,7 +65,7 @@ class Request extends Error implements Parser
     {
         $data = [];
 
-        $properties = new BackwardCompatibility();
+        $properties = new Current();
 
         return array_merge(
             $data,
@@ -76,7 +75,6 @@ class Request extends Error implements Parser
             Method::getData($properties),
             Mode::getData($boleto, $properties),
             ReceiverEmail::getData($boleto, $properties),
-            Split::getData($boleto, $properties),
             Sender::getData($boleto, $properties),
             Shipping::getData($boleto, $properties)
         );

--- a/source/Parsers/DirectPayment/Boleto/Split/Request.php
+++ b/source/Parsers/DirectPayment/Boleto/Split/Request.php
@@ -22,62 +22,64 @@
  *
  */
 
-namespace PagSeguro\Parsers\DirectPayment\InternationalCreditCard;
+namespace PagSeguro\Parsers\DirectPayment\Boleto\Split;
 
 /**
- * Request from the Credit Card direct payment
- * @package PagSeguro\Parsers\DirectPayment\CreditCard
+ * Request from the Boleto direct payment
+ *
+ * @package PagSeguro\Parsers\DirectPayment\Boleto
  */
-use PagSeguro\Enum\Properties\Current;
+use PagSeguro\Enum\Properties\BackwardCompatibility;
 use PagSeguro\Parsers\Basic;
 use PagSeguro\Parsers\Currency;
-use PagSeguro\Parsers\DirectPayment\CreditCard\Installment;
-use PagSeguro\Parsers\DirectPayment\CreditCard\Method;
-use PagSeguro\Parsers\DirectPayment\CreditCard\Token;
 use PagSeguro\Parsers\DirectPayment\Mode;
 use PagSeguro\Parsers\Error;
 use PagSeguro\Parsers\Item;
 use PagSeguro\Parsers\Parser;
 use PagSeguro\Parsers\ReceiverEmail;
 use PagSeguro\Parsers\Sender;
+use PagSeguro\Parsers\Shipping;
+use PagSeguro\Parsers\Split;
 use PagSeguro\Resources\Http;
-use PagSeguro\Parsers\Transaction\InternationalCreditCard\Response;
+use PagSeguro\Parsers\Transaction\Boleto\Response;
+use PagSeguro\Parsers\DirectPayment\Boleto\Method;
 
 /**
  * Class Payment
- * @package PagSeguro\Parsers\DirectPayment\CreditCard
+ * @package PagSeguro\Parsers\DirectPayment\Boleto
  */
 class Request extends Error implements Parser
 {
     use Basic;
     use Currency;
-    use Installment;
     use Item;
     use Method;
     use Mode;
     use ReceiverEmail;
     use Sender;
-    use Token;
+    use Shipping;
 
     /**
-     * @param \PagSeguro\Domains\Requests\DirectPayment\CreditCard $creditCard
+     * @param \PagSeguro\Domains\Requests\DirectPayment\Boleto $boleto
      * @return array
      */
-    public static function getData(\PagSeguro\Domains\Requests\Requests $creditCard)
+    public static function getData(\PagSeguro\Domains\Requests\DirectPayment\Boleto $boleto)
     {
         $data = [];
-        $properties = new Current();
+
+        $properties = new BackwardCompatibility();
+
         return array_merge(
             $data,
-            Basic::getData($creditCard, $properties),
-            Currency::getData($creditCard, $properties),
-            Installment::getData($creditCard, $properties),
-            Item::getData($creditCard, $properties),
+            Basic::getData($boleto, $properties),
+            Currency::getData($boleto, $properties),
+            Item::getData($boleto, $properties),
             Method::getData($properties),
-            Mode::getData($creditCard, $properties),
-            ReceiverEmail::getData($creditCard, $properties),
-            Sender::getData($creditCard, $properties),
-            Token::getData($creditCard, $properties)
+            Mode::getData($boleto, $properties),
+            ReceiverEmail::getData($boleto, $properties),
+            Split::getData($boleto, $properties),
+            Sender::getData($boleto, $properties),
+            Shipping::getData($boleto, $properties)
         );
     }
 
@@ -92,11 +94,12 @@ class Request extends Error implements Parser
         return (new Response)->setDate(current($xml->date))
             ->setCode(current($xml->code))
             ->setReference(current($xml->reference))
-            ->setRecoveryCode(current($xml->recoveryCode))
             ->setType(current($xml->type))
             ->setStatus(current($xml->status))
             ->setLastEventDate(current($xml->lastEventDate))
             ->setCancelationSource(current($xml->cancelationSource))
+            ->setCreditorFees($xml->creditorFees)
+            ->setPaymentLink(current($xml->paymentLink))
             ->setPaymentMethod($xml->paymentMethod)
             ->setGrossAmount(current($xml->grossAmount))
             ->setDiscountAmount(current($xml->discountAmount))
@@ -108,9 +111,8 @@ class Request extends Error implements Parser
             ->setItemCount(current($xml->itemCount))
             ->setItems($xml->items)
             ->setSender($xml->sender)
-            ->setCreditorFees($xml->creditorFees)
-            ->setApplication($xml->applications)
-            ->setGatewaySystem($xml->gatewaySystem);
+            ->setShipping($xml->shipping)
+            ->setApplication($xml->applications);
     }
 
     /**

--- a/source/Parsers/DirectPayment/CreditCard/Request.php
+++ b/source/Parsers/DirectPayment/CreditCard/Request.php
@@ -28,7 +28,6 @@ namespace PagSeguro\Parsers\DirectPayment\CreditCard;
  * Request from the Credit Card direct payment
  * @package PagSeguro\Parsers\DirectPayment\CreditCard
  */
-use PagSeguro\Enum\Properties\BackwardCompatibility;
 use PagSeguro\Enum\Properties\Current;
 use PagSeguro\Parsers\Basic;
 use PagSeguro\Parsers\Currency;
@@ -43,7 +42,6 @@ use PagSeguro\Parsers\Parser;
 use PagSeguro\Parsers\ReceiverEmail;
 use PagSeguro\Parsers\Sender;
 use PagSeguro\Parsers\Shipping;
-use PagSeguro\Parsers\Split;
 use PagSeguro\Resources\Http;
 use PagSeguro\Parsers\Transaction\CreditCard\Response;
 
@@ -72,7 +70,7 @@ class Request extends Error implements Parser
     {
 
         $data = [];
-        $properties = new BackwardCompatibility();
+        $properties = new Current();
         return array_merge(
             $data,
             Basic::getData($creditCard, $properties),
@@ -86,8 +84,7 @@ class Request extends Error implements Parser
             ReceiverEmail::getData($creditCard, $properties),
             Sender::getData($creditCard, $properties),
             Shipping::getData($creditCard, $properties),
-            Token::getData($creditCard, $properties),
-            Split::getData($creditCard, $properties)
+            Token::getData($creditCard, $properties)
         );
     }
 

--- a/source/Parsers/DirectPayment/InternationalCreditCard/Split/Request.php
+++ b/source/Parsers/DirectPayment/InternationalCreditCard/Split/Request.php
@@ -22,13 +22,13 @@
  *
  */
 
-namespace PagSeguro\Parsers\DirectPayment\InternationalCreditCard;
+namespace PagSeguro\Parsers\DirectPayment\InternationalCreditCard\Split;
 
 /**
  * Request from the Credit Card direct payment
  * @package PagSeguro\Parsers\DirectPayment\CreditCard
  */
-use PagSeguro\Enum\Properties\Current;
+use PagSeguro\Enum\Properties\BackwardCompatibility;
 use PagSeguro\Parsers\Basic;
 use PagSeguro\Parsers\Currency;
 use PagSeguro\Parsers\DirectPayment\CreditCard\Installment;
@@ -40,6 +40,7 @@ use PagSeguro\Parsers\Item;
 use PagSeguro\Parsers\Parser;
 use PagSeguro\Parsers\ReceiverEmail;
 use PagSeguro\Parsers\Sender;
+use PagSeguro\Parsers\Split;
 use PagSeguro\Resources\Http;
 use PagSeguro\Parsers\Transaction\InternationalCreditCard\Response;
 
@@ -66,7 +67,7 @@ class Request extends Error implements Parser
     public static function getData(\PagSeguro\Domains\Requests\Requests $creditCard)
     {
         $data = [];
-        $properties = new Current();
+        $properties = new BackwardCompatibility();
         return array_merge(
             $data,
             Basic::getData($creditCard, $properties),
@@ -77,6 +78,7 @@ class Request extends Error implements Parser
             Mode::getData($creditCard, $properties),
             ReceiverEmail::getData($creditCard, $properties),
             Sender::getData($creditCard, $properties),
+            Split::getData($creditCard, $properties),
             Token::getData($creditCard, $properties)
         );
     }

--- a/source/Parsers/DirectPayment/OnlineDebit/Request.php
+++ b/source/Parsers/DirectPayment/OnlineDebit/Request.php
@@ -28,7 +28,6 @@ namespace PagSeguro\Parsers\DirectPayment\OnlineDebit;
  * Request from the Online debit direct payment
  * @package PagSeguro\Parsers\DirectPayment\OnlineDebit
  */
-use PagSeguro\Enum\Properties\BackwardCompatibility;
 use PagSeguro\Enum\Properties\Current;
 use PagSeguro\Parsers\Basic;
 use PagSeguro\Parsers\Currency;
@@ -39,7 +38,6 @@ use PagSeguro\Parsers\Parser;
 use PagSeguro\Parsers\ReceiverEmail;
 use PagSeguro\Parsers\Sender;
 use PagSeguro\Parsers\Shipping;
-use PagSeguro\Parsers\Split;
 use PagSeguro\Resources\Http;
 use PagSeguro\Parsers\Transaction\OnlineDebit\Response;
 
@@ -66,7 +64,7 @@ class Request extends Error implements Parser
     public static function getData(\PagSeguro\Domains\Requests\DirectPayment\OnlineDebit $onlineDebit)
     {
         $data = [];
-        $properties = new BackwardCompatibility();
+        $properties = new Current();
         return array_merge(
             $data,
             BankName::getData($onlineDebit, $properties),
@@ -77,8 +75,7 @@ class Request extends Error implements Parser
             Mode::getData($onlineDebit, $properties),
             ReceiverEmail::getData($onlineDebit, $properties),
             Sender::getData($onlineDebit, $properties),
-            Shipping::getData($onlineDebit, $properties),
-            Split::getData($onlineDebit, $properties)
+            Shipping::getData($onlineDebit, $properties)
         );
     }
 

--- a/source/Parsers/DirectPayment/OnlineDebit/Split/Request.php
+++ b/source/Parsers/DirectPayment/OnlineDebit/Split/Request.php
@@ -22,62 +22,64 @@
  *
  */
 
-namespace PagSeguro\Parsers\DirectPayment\InternationalCreditCard;
+namespace PagSeguro\Parsers\DirectPayment\OnlineDebit\Split;
 
 /**
- * Request from the Credit Card direct payment
- * @package PagSeguro\Parsers\DirectPayment\CreditCard
+ * Request from the Online debit direct payment
+ * @package PagSeguro\Parsers\DirectPayment\OnlineDebit
  */
-use PagSeguro\Enum\Properties\Current;
+use PagSeguro\Enum\Properties\BackwardCompatibility;
 use PagSeguro\Parsers\Basic;
 use PagSeguro\Parsers\Currency;
-use PagSeguro\Parsers\DirectPayment\CreditCard\Installment;
-use PagSeguro\Parsers\DirectPayment\CreditCard\Method;
-use PagSeguro\Parsers\DirectPayment\CreditCard\Token;
 use PagSeguro\Parsers\DirectPayment\Mode;
 use PagSeguro\Parsers\Error;
 use PagSeguro\Parsers\Item;
 use PagSeguro\Parsers\Parser;
 use PagSeguro\Parsers\ReceiverEmail;
 use PagSeguro\Parsers\Sender;
+use PagSeguro\Parsers\Shipping;
+use PagSeguro\Parsers\Split;
 use PagSeguro\Resources\Http;
-use PagSeguro\Parsers\Transaction\InternationalCreditCard\Response;
+use PagSeguro\Parsers\Transaction\OnlineDebit\Response;
+use PagSeguro\Parsers\DirectPayment\OnlineDebit\Method;
+use PagSeguro\Parsers\DirectPayment\OnlineDebit\BankName;
 
 /**
  * Class Payment
- * @package PagSeguro\Parsers\DirectPayment\CreditCard
+ * @package PagSeguro\Parsers\DirectPayment\OnlineDebit
  */
 class Request extends Error implements Parser
 {
+    use BankName;
     use Basic;
     use Currency;
-    use Installment;
     use Item;
     use Method;
     use Mode;
     use ReceiverEmail;
     use Sender;
-    use Token;
+    use Shipping;
 
     /**
-     * @param \PagSeguro\Domains\Requests\DirectPayment\CreditCard $creditCard
+     * @param \PagSeguro\Domains\Requests\DirectPayment\OnlineDebit $onlineDebit
      * @return array
      */
-    public static function getData(\PagSeguro\Domains\Requests\Requests $creditCard)
+    public static function getData(\PagSeguro\Domains\Requests\DirectPayment\OnlineDebit $onlineDebit)
     {
         $data = [];
-        $properties = new Current();
+        $properties = new BackwardCompatibility();
         return array_merge(
             $data,
-            Basic::getData($creditCard, $properties),
-            Currency::getData($creditCard, $properties),
-            Installment::getData($creditCard, $properties),
-            Item::getData($creditCard, $properties),
+            BankName::getData($onlineDebit, $properties),
+            Basic::getData($onlineDebit, $properties),
+            Currency::getData($onlineDebit, $properties),
+            Item::getData($onlineDebit, $properties),
             Method::getData($properties),
-            Mode::getData($creditCard, $properties),
-            ReceiverEmail::getData($creditCard, $properties),
-            Sender::getData($creditCard, $properties),
-            Token::getData($creditCard, $properties)
+            Mode::getData($onlineDebit, $properties),
+            ReceiverEmail::getData($onlineDebit, $properties),
+            Sender::getData($onlineDebit, $properties),
+            Shipping::getData($onlineDebit, $properties),
+            Split::getData($onlineDebit, $properties)
         );
     }
 
@@ -97,6 +99,7 @@ class Request extends Error implements Parser
             ->setStatus(current($xml->status))
             ->setLastEventDate(current($xml->lastEventDate))
             ->setCancelationSource(current($xml->cancelationSource))
+            ->setPaymentLink(current($xml->paymentLink))
             ->setPaymentMethod($xml->paymentMethod)
             ->setGrossAmount(current($xml->grossAmount))
             ->setDiscountAmount(current($xml->discountAmount))
@@ -110,7 +113,7 @@ class Request extends Error implements Parser
             ->setSender($xml->sender)
             ->setCreditorFees($xml->creditorFees)
             ->setApplication($xml->applications)
-            ->setGatewaySystem($xml->gatewaySystem);
+            ->setShipping($xml->shipping);
     }
 
     /**

--- a/source/Parsers/Response/CreditorFees.php
+++ b/source/Parsers/Response/CreditorFees.php
@@ -52,8 +52,15 @@ trait CreditorFees
     public function setCreditorFees($creditorFees)
     {
         $creditor = new \PagSeguro\Domains\CreditorFees();
-        $creditor->setIntermediationRateAmount(current($creditorFees->intermediationRateAmount))
-            ->setIntermediationFeeAmount(current($creditorFees->intermediationFeeAmount));
+
+        if (!is_null($creditorFees->intermediationRateAmount)) {
+            $creditor->setIntermediationRateAmount(current($creditorFees->intermediationRateAmount));
+        }
+        
+        if (!is_null($creditorFees->intermediationFeeAmount)) {
+            $creditor->setIntermediationFeeAmount(current($creditorFees->intermediationFeeAmount));
+        }
+
         $this->creditorFees = $creditor;
         return $this;
     }

--- a/source/Resources/Builder/DirectPayment/Payment.php
+++ b/source/Resources/Builder/DirectPayment/Payment.php
@@ -32,7 +32,6 @@ use PagSeguro\Resources\Builder;
  */
 class Payment extends Builder
 {
-
     /**
      * @return string
      */

--- a/source/Resources/Builder/DirectPayment/PaymentWithSplit.php
+++ b/source/Resources/Builder/DirectPayment/PaymentWithSplit.php
@@ -22,33 +22,25 @@
  *
  */
 
-namespace PagSeguro\Domains\Requests\DirectPayment;
+namespace PagSeguro\Resources\Builder\DirectPayment;
 
-use PagSeguro\Domains\Requests\DirectPayment\Boleto\Request;
+use PagSeguro\Resources\Builder;
 
 /**
  * Class Payment
- * @package PagSeguro\Domains\Requests
+ * @package PagSeguro\Resources\Builder
  */
-class Boleto extends Request
+class PaymentWithSplit extends Builder
 {
+
     /**
-     * @param $credentials
      * @return string
-     * @throws \Exception
      */
-    public function register($credentials)
+    public static function getRequestUrl()
     {
-        return \PagSeguro\Services\DirectPayment\Boleto::checkout($credentials, $this);
-    }
-    
-    /**
-     * @param $credentials
-     * @return string
-     * @throws \Exception
-     */
-    public function registerWithSplit($credentials)
-    {
-        return \PagSeguro\Services\DirectPayment\Boleto::checkoutWithSplit($credentials, $this);
+        return parent::getRequest(
+            parent::getUrl('webservice'),
+            'directPaymentWithSplit'
+        );
     }
 }

--- a/source/Resources/Connection/Base/DirectPayment/Payment.php
+++ b/source/Resources/Connection/Base/DirectPayment/Payment.php
@@ -39,4 +39,13 @@ trait Payment
     {
         return Builder\DirectPayment\Payment::getRequestUrl();
     }
+    
+    /**
+     * @return string
+     */
+    public function buildDirectPaymentWithSplitRequestUrl()
+    {
+        return Builder\DirectPayment\PaymentWithSplit::getRequestUrl();
+    }
+    
 }

--- a/source/Services/DirectPayment/InternationalCreditCard.php
+++ b/source/Services/DirectPayment/InternationalCreditCard.php
@@ -28,6 +28,7 @@ use PagSeguro\Domains\Account\Credentials;
 use PagSeguro\Helpers\Crypto;
 use PagSeguro\Helpers\Mask;
 use PagSeguro\Parsers\DirectPayment\InternationalCreditCard\Request;
+use PagSeguro\Parsers\DirectPayment\InternationalCreditCard\Split\Request as SplitRequest;
 use PagSeguro\Resources\Connection;
 use PagSeguro\Resources\Http;
 use PagSeguro\Resources\Log\Logger;
@@ -90,11 +91,70 @@ class InternationalCreditCard
     }
 
     /**
+     * @param \PagSeguro\Domains\Account\Credentials $credentials
+     * @param \PagSeguro\Domains\Requests\DirectPayment\OnlineDebit $payment
+     * @return string
+     * @throws \Exception
+     */
+    public static function checkoutWithSplit(
+        Credentials $credentials,
+        \PagSeguro\Domains\Requests\DirectPayment\InternationalCreditCard $payment
+    ) {
+        Logger::info("Begin", ['service' => 'DirectPayment.InternationalCreditCard.Split']);
+        try {
+            $connection = new Connection\Data($credentials);
+            $http = new Http();
+            Logger::info(
+                sprintf("POST: %s", self::requestWithSplit($connection)),
+                ['service' => 'DirectPayment.InternationalCreditCard.Split']
+            );
+            Logger::info(
+                sprintf(
+                    "Params: %s",
+                    json_encode(Crypto::encrypt(SplitRequest::getData($payment)))
+                ),
+                ['service' => 'DirectPayment.InternationalCreditCard.Split']
+            );
+            $http->post(
+                self::requestWithSplit($connection),
+                SplitRequest::getData($payment)
+            );
+
+            $response = Responsibility::http(
+                $http,
+                new SplitRequest
+            );
+
+            Logger::info(
+                sprintf("International Credit Card Payment code: %s", $response->getCode()),
+                ['service' => 'DirectPayment.InternationalCreditCard.Split']
+            );
+
+            return $response;
+        } catch (\Exception $exception) {
+            Logger::error(
+                $exception->getMessage(),
+                ['service' => 'DirectPayment.InternationalCreditCard.Split']
+            );
+            throw $exception;
+        }
+    }
+    
+    /**
      * @param Connection\Data $connection
      * @return string
      */
     private static function request(Connection\Data $connection)
     {
         return $connection->buildDirectPaymentRequestUrl() ."?". $connection->buildCredentialsQuery();
+    }
+
+    /**
+     * @param Connection\Data $connection
+     * @return string
+     */
+    private static function requestWithSplit(Connection\Data $connection)
+    {
+        return $connection->buildDirectPaymentWithSplitRequestUrl() ."?". $connection->buildCredentialsQuery();
     }
 }

--- a/source/Services/DirectPayment/OnlineDebit.php
+++ b/source/Services/DirectPayment/OnlineDebit.php
@@ -28,6 +28,7 @@ use PagSeguro\Domains\Account\Credentials;
 use PagSeguro\Helpers\Crypto;
 use PagSeguro\Helpers\Mask;
 use PagSeguro\Parsers\DirectPayment\OnlineDebit\Request;
+use PagSeguro\Parsers\DirectPayment\OnlineDebit\Split\Request as SplitRequest;
 use PagSeguro\Resources\Connection;
 use PagSeguro\Resources\Http;
 use PagSeguro\Resources\Log\Logger;
@@ -87,11 +88,67 @@ class OnlineDebit
     }
 
     /**
+     * @param \PagSeguro\Domains\Account\Credentials $credentials
+     * @param \PagSeguro\Domains\Requests\DirectPayment\OnlineDebit $payment
+     * @return string
+     * @throws \Exception
+     */
+    public static function checkoutWithSplit(
+        Credentials $credentials,
+        \PagSeguro\Domains\Requests\DirectPayment\OnlineDebit $payment
+    ) {
+        Logger::info("Begin", ['service' => 'DirectPayment.OnlineDebit.Split']);
+        try {
+            $connection = new Connection\Data($credentials);
+            $http = new Http();
+            Logger::info(
+                sprintf("POST: %s", self::requestWithSplit($connection)),
+                ['service' => 'DirectPayment.OnlineDebit.Split']
+            );
+            Logger::info(
+                sprintf(
+                    "Params: %s",
+                    json_encode(Crypto::encrypt(SplitRequest::getData($payment)))
+                ),
+                ['service' => 'Checkout']
+            );
+            $http->post(
+                self::requestWithSplit($connection),
+                SplitRequest::getData($payment)
+            );
+
+            $response = Responsibility::http(
+                $http,
+                new SplitRequest
+            );
+
+            Logger::info(
+                sprintf("Online Debit Payment Link URL: %s", $response->getPaymentLink()),
+                ['service' => 'DirectPayment.OnlineDebit.Split']
+            );
+
+            return $response;
+        } catch (\Exception $exception) {
+            Logger::error($exception->getMessage(), ['service' => 'DirectPayment.OnlineDebit']);
+            throw $exception;
+        }
+    }
+    
+    /**
      * @param Connection\Data $connection
      * @return string
      */
     private static function request(Connection\Data $connection)
     {
         return $connection->buildDirectPaymentRequestUrl() ."?". $connection->buildCredentialsQuery();
+    }
+    
+    /**
+     * @param Connection\Data $connection
+     * @return string
+     */
+    private static function requestWithSplit(Connection\Data $connection)
+    {
+        return $connection->buildDirectPaymentWithSplitRequestUrl() ."?". $connection->buildCredentialsQuery();
     }
 }


### PR DESCRIPTION
- Changed endpoint for direct payment, that now uses `v2/transactions` while Direct Payment with Split uses `/transactions`
- Created new register methods (registerWithSplit) for every direct payment option to do direct payments with split
- General fixes and upgrades