### PR TITLE
Link de pagamento (paymentLink) na busca de transações por código

### DIFF
--- a/source/Parsers/Transaction/Response.php
+++ b/source/Parsers/Transaction/Response.php
@@ -41,6 +41,7 @@ class Response
     use Currency;
     use CreditorFees;
     use Item;
+    use PaymentLink;
     use PaymentMethod;
     use Sender;
     use Shipping;

--- a/source/Parsers/Transaction/Search/Code/Request.php
+++ b/source/Parsers/Transaction/Search/Code/Request.php
@@ -67,6 +67,7 @@ class Request extends Error implements Parser
             ->setStatus(current($xml->status))
             ->setLastEventDate(current($xml->lastEventDate))
             ->setPaymentMethod($xml->paymentMethod)
+            ->setPaymentLink(current($xml->paymentLink))
             ->setGrossAmount(current($xml->grossAmount))
             ->setDiscountAmount(current($xml->discountAmount))
             ->setCreditorFees($xml->creditorFees)


### PR DESCRIPTION
O atributo `paymentLink` não está sendo adicionado na resposta da busca de transações por código.

Conforme a documentação:

> Para os meios Boleto e Débito, o XML possui o item `paymentLink` que retorna um link acesso, respectivamente, a imagem do boleto e para a página de pagamento do banco selecionado.
> https://dev.pagseguro.uol.com.br/documentacao/pagamento-online/pagamentos/pagamento-transparente

Apesar de só constar na documentação do pagamento transparente, o PagSeguro fornece o `paymentLink` no pagamento normal também.

Estou submetendo este PR incluindo as modificações necessárias para que o `paymentLink` funcione com a busca por código das transações. O atributo não foi adicionado na busca por datas pois a API não o fornece.