### PR TITLE
fix: shipping response parser

### DIFF
--- a/source/Parsers/Response/Shipping.php
+++ b/source/Parsers/Response/Shipping.php
@@ -54,28 +54,30 @@ trait Shipping
      */
     public function setShipping($shipping)
     {
-        $shippingClass = new \PagSeguro\Domains\Shipping();
+        if (current($shipping) !== FALSE) {
+            $shippingClass = new \PagSeguro\Domains\Shipping();
 
-        $shippingAddress = new Address($shippingClass);
+            $shippingAddress = new Address($shippingClass);
 
-        $shippingAddress->withParameters(
-            current($shipping->address->street),
-            current($shipping->address->number),
-            current($shipping->address->district),
-            current($shipping->address->postalCode),
-            current($shipping->address->city),
-            current($shipping->address->state),
-            current($shipping->address->country), 
-            current($shipping->address->complement)
-        );
+            $shippingAddress->withParameters(
+                current($shipping->address->street),
+                current($shipping->address->number),
+                current($shipping->address->district),
+                current($shipping->address->postalCode),
+                current($shipping->address->city),
+                current($shipping->address->state),
+                current($shipping->address->country), 
+                current($shipping->address->complement)
+            );
 
-        $shippingType = new Type($shippingClass);
-        $shippingType->withParameters(current($shipping->type));
+            $shippingType = new Type($shippingClass);
+            $shippingType->withParameters(current($shipping->type));
 
-        $shippingCost = new Cost($shippingClass);
-        $shippingCost->withParameters(current($shipping->cost));
+            $shippingCost = new Cost($shippingClass);
+            $shippingCost->withParameters(current($shipping->cost));
 
-        $this->shipping = $shippingClass;
+            $this->shipping = $shippingClass;
+        }
         return $this;
     }
 }


### PR DESCRIPTION
Added validation to avoid php warning when there is no shipping data to be parsed (like in international credit card or if it is optional)