### PR TITLE
Constante indefinda

### DIFF
--- a/source/Parsers/DirectPayment/CreditCard/Installment.php
+++ b/source/Parsers/DirectPayment/CreditCard/Installment.php
@@ -53,7 +53,7 @@ trait Installment
         }
         // setNoInterestInstallmentQuantity
         if (!is_null($installment->getNoInterestInstallmentQuantity())) {
-            $data[$properties::INSTALLMENT_NO_INTEREST_INSTALLMENT_QUANTITY] = Currency::toDecimal($installment->getNoInterestInstallmentQuantity());
+            $data[$properties::INSTALLMENT_MAX_INSTALLMENT_NO_INTEREST] = Currency::toDecimal($installment->getNoInterestInstallmentQuantity());
         }
 
         return $data;


### PR DESCRIPTION
A constante INSTALLMENT_NO_INTEREST_INSTALLMENT_QUANTITY está indefinida nas propiedades do Enum/Properties/Current.php

A cosntante definida la é a : INSTALLMENT_MAX_INSTALLMENT_NO_INTEREST

Apenas fiz a substituição para quem usa a API do pagseguro em PHP pra parcelar a compra