### PR TITLE
fix:  "already defined constant" errors

### DIFF
--- a/source/Library.php
+++ b/source/Library.php
@@ -39,7 +39,7 @@ class Library
     /**
      *
      */
-    const VERSION = "3.0.0";
+    const VERSION = "3.3.2";
     /**
      * @var
      */
@@ -55,10 +55,10 @@ class Library
     final public static function initialize()
     {
         //Basic configuration
-        define('PS_BASEPATH', __DIR__);
-        define('PS_CONFIG_PATH', PS_BASEPATH. "/Configuration/");
-        define('PS_CONFIG', PS_CONFIG_PATH."Properties/Conf.xml");
-        define('PS_RESOURCES', PS_CONFIG_PATH."Properties/Resources.xml");
+        defined('PS_BASEPATH') or define('PS_BASEPATH', __DIR__);
+        defined('PS_CONFIG_PATH') or define('PS_CONFIG_PATH', PS_BASEPATH. "/Configuration/");
+        defined('PS_CONFIG') or define('PS_CONFIG', PS_CONFIG_PATH."Properties/Conf.xml");
+        defined('PS_RESOURCES') or define('PS_RESOURCES', PS_CONFIG_PATH."Properties/Resources.xml");
         //Validates for cUrl and SimpleXml.
         self::validate();
         //Garbage Collection


### PR DESCRIPTION
Fix eventual php notice errors "already defined constant".
Updated "VERSION" constant