### PR TITLE
Correção de métodos de pagamento.

### DIFF
--- a/source/Parsers/Accepted.php
+++ b/source/Parsers/Accepted.php
@@ -38,8 +38,10 @@ trait Accepted
         if (!is_null($request->acceptedPaymentMethods())) {
             $accepted = $request->acceptedPaymentMethods();
             if (!is_null($accepted['accept'])) {
-                $data[$properties::ACCEPT_PAYMENT_METHOD_GROUP] =
-                    implode(',', current($accepted['accept'])->getGroups());
+                if (!is_null(current($accepted['accept'])->getGroups())) {
+                    $data[$properties::ACCEPT_PAYMENT_METHOD_GROUP] =
+                        implode(',', current($accepted['accept'])->getGroups());
+                }
                 if (!is_null(current($accepted['accept'])->getNames())) {
                     $data[$properties::ACCEPT_PAYMENT_METHOD_NAME] =
                         implode(',', current($accepted['accept'])->getNames());


### PR DESCRIPTION
Após efetuar uns testes, verifiquei que a programação não estava verificando se não existia grupos de pagamento, desde que não enviássemos um grupo de pagamento ele retornava erro, corrigido para adicionar método de pagamento através de nome.