### PR TITLE
Ao enviar a requisição o getItems sempre trazia um objeto e o is_arra…

### DIFF
--- a/source/Domains/Requests/Item.php
+++ b/source/Domains/Requests/Item.php
@@ -59,11 +59,11 @@ trait Item
 
     public function getItems()
     {
-        return current($this->items);
+        return $this->items;
     }
 
     public function itemLenght()
     {
-        return count(current($this->items));
+        return is_array($this->items) ? count($this->items) : 0;
     }
 }

--- a/source/Domains/Requests/PaymentMethod.php
+++ b/source/Domains/Requests/PaymentMethod.php
@@ -64,6 +64,6 @@ trait PaymentMethod
 
     public function paymentMethodLenght()
     {
-        return count($this->paymentMethod);
+        return is_array($this->paymentMethod) ? count($this->paymentMethod) : 0;
     }
 }


### PR DESCRIPTION
Ao enviar a requisição o getItems sempre trazia um objeto e o is_array é para o uso no php 7.2, pois o count não aceita nulo