### PR TITLE
fix:tests - deverá ser criada uma nova release 4.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,8 @@ composer.lock
 ## Lib
 #################
 *.log
+
+#################
+## Code Coverage
+#################
+/tests/codeCoverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 4.2.1 (16/08/2018)
+
+#### Correções
+- **dev (testes de unidade):**
+    * os quebrados foram corrigidos
+    * agora estão separados em suites
+    * novos casos foram implementados
+    * namespace específico para testes foi adicionado "Pagseguro/Tests"
+    * logs em html serão criado na pasta ignorada "tests/codeCoverage"
+
 ### 4.2.0 (19/03/2018)
 
 #### Funcionalidades

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,10 @@
     "psr-4": {
       "PagSeguro\\": "source/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "PagSeguro\\Tests\\": "tests/"
+    }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false">
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./source</directory>
+        </whitelist>
+    </filter>
+
+    <testsuites>
+        <testsuite name="general">
+            <directory>tests</directory>
+        </testsuite>
+
+        <testsuite name="directPreApproval">
+            <directory>tests/Domains/DirectPreApproval</directory>
+        </testsuite>
+    </testsuites>
+
+    <logging>
+        <log type="coverage-html" target="tests/codeCoverage/html"
+             lowUpperBound="50"  highLowerBound="80" charset="UTF-8"/>
+    </logging>
+</phpunit>

--- a/tests/Domains/DirectPreApproval/AddressTest.php
+++ b/tests/Domains/DirectPreApproval/AddressTest.php
@@ -1,34 +1,35 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 10:00
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\Address;
 
 class AddressTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
 
-    public function testParameters()
+    protected function setUp()
+    {
+        $this->obj = new Address();
+    }
+
+    /**
+     * @todo implement assertInstanceOf
+     */
+
+    public function testRequiredParameters()
     {
         $this->assertObjectHasAttribute('street', $this->obj);
         $this->assertObjectHasAttribute('number', $this->obj);
         $this->assertObjectHasAttribute('district', $this->obj);
+        $this->assertObjectHasAttribute('postalCode', $this->obj);
         $this->assertObjectHasAttribute('city', $this->obj);
         $this->assertObjectHasAttribute('state', $this->obj);
         $this->assertObjectHasAttribute('country', $this->obj);
     }
 
-    public function testWithParameters()
+    public function testParametersThatCanBeNull()
     {
-        $this->assertInstanceOf(Address::class, $this->obj);
-    }
-
-    protected function setUp()
-    {
-        $this->obj = new Address();
+        $this->assertNull($this->obj->complement);
     }
 }

--- a/tests/Domains/DirectPreApproval/BillingAddressTest.php
+++ b/tests/Domains/DirectPreApproval/BillingAddressTest.php
@@ -1,34 +1,35 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 11:48
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\BillingAddress;
 
 class BillingAddressTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
 
-    public function testParameters()
+    protected function setUp()
+    {
+        $this->obj = new BillingAddress();
+    }
+
+    /**
+     * @todo implement assertInstanceOf
+     */
+
+    public function testRequiredParameters()
     {
         $this->assertObjectHasAttribute('street', $this->obj);
         $this->assertObjectHasAttribute('number', $this->obj);
         $this->assertObjectHasAttribute('district', $this->obj);
+        $this->assertObjectHasAttribute('postalCode', $this->obj);
         $this->assertObjectHasAttribute('city', $this->obj);
         $this->assertObjectHasAttribute('state', $this->obj);
         $this->assertObjectHasAttribute('country', $this->obj);
     }
 
-    public function testWithParameters()
+    public function testParametersThatCanBeNull()
     {
-        $this->assertInstanceOf(BillingAddress::class, $this->obj);
-    }
-
-    protected function setUp()
-    {
-        $this->obj = new BillingAddress();
+        $this->assertNull($this->obj->complement);
     }
 }

--- a/tests/Domains/DirectPreApproval/CreditCardTest.php
+++ b/tests/Domains/DirectPreApproval/CreditCardTest.php
@@ -1,24 +1,20 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 11:51
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\CreditCard;
 
 class CreditCardTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
 
-    public function testSetHolder()
-    {
-        $this->assertInstanceOf(CreditCard::class, $this->obj);
-    }
-
     protected function setUp()
     {
         $this->obj = new CreditCard();
     }
+
+    /**
+     * @todo implement tests
+     */
+
 }

--- a/tests/Domains/DirectPreApproval/DocumentTest.php
+++ b/tests/Domains/DirectPreApproval/DocumentTest.php
@@ -1,25 +1,25 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 11:54
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\Document;
 
 class DocumentTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
 
-    public function testParameters()
-    {
-        $this->assertObjectHasAttribute('type', $this->obj);
-        $this->assertObjectHasAttribute('value', $this->obj);
-    }
-
     protected function setUp()
     {
         $this->obj = new Document();
+    }
+
+    /**
+     * @todo implement assertInstanceOf
+     */
+
+    public function testRequiredParameters()
+    {
+        $this->assertObjectHasAttribute('type', $this->obj);
+        $this->assertObjectHasAttribute('value', $this->obj);
     }
 }

--- a/tests/Domains/DirectPreApproval/ExpirationTest.php
+++ b/tests/Domains/DirectPreApproval/ExpirationTest.php
@@ -1,30 +1,25 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 13:14
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\Expiration;
 
 class ExpirationTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
 
-    public function testParameters()
-    {
-        $this->assertObjectHasAttribute('value', $this->obj);
-        $this->assertObjectHasAttribute('unit', $this->obj);
-    }
-
-    public function testWithParameters()
-    {
-        $this->assertInstanceOf(Expiration::class, $this->obj);
-    }
-
     protected function setUp()
     {
         $this->obj = new Expiration();
+    }
+
+    /**
+     * @todo implement assertInstanceOf
+     */
+
+    public function testRequiredParameters()
+    {
+        $this->assertObjectHasAttribute('value', $this->obj);
+        $this->assertObjectHasAttribute('unit', $this->obj);
     }
 }

--- a/tests/Domains/DirectPreApproval/HolderTest.php
+++ b/tests/Domains/DirectPreApproval/HolderTest.php
@@ -1,24 +1,19 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 13:18
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\Holder;
 
 class HolderTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
 
-    public function testSetBillingAddress()
-    {
-        $this->assertInstanceOf(Holder::class, $this->obj);
-    }
-
     protected function setUp()
     {
         $this->obj = new Holder();
     }
+
+    /**
+     * @todo implement tests
+     */
 }

--- a/tests/Domains/DirectPreApproval/ItemTest.php
+++ b/tests/Domains/DirectPreApproval/ItemTest.php
@@ -1,34 +1,33 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 13:33
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\Item;
 
 class ItemTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
 
-    public function testParameters()
+    protected function setUp()
+    {
+        $this->obj = new Item();
+    }
+
+    /**
+     * @todo implement assertInstanceOf
+     */
+
+    public function testRequiredParameters()
     {
         $this->assertObjectHasAttribute('id', $this->obj);
         $this->assertObjectHasAttribute('description', $this->obj);
         $this->assertObjectHasAttribute('quantity', $this->obj);
         $this->assertObjectHasAttribute('amount', $this->obj);
-        $this->assertObjectHasAttribute('weight', $this->obj);
-        $this->assertObjectHasAttribute('shippingCost', $this->obj);
     }
 
-    public function testWithPArameters()
+    public function testParametersThatCanBeNull()
     {
-        $this->assertInstanceOf(Item::class, $this->obj);
-    }
-
-    protected function setUp()
-    {
-        $this->obj = new Item();
+        $this->assertNull($this->obj->weight);
+        $this->assertNull($this->obj->shippingCost);
     }
 }

--- a/tests/Domains/DirectPreApproval/PaymentMethodTest.php
+++ b/tests/Domains/DirectPreApproval/PaymentMethodTest.php
@@ -1,29 +1,24 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 13:35
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\PaymentMethod;
 
 class PaymentMethodTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
 
-    public function testParameters()
-    {
-        $this->assertObjectHasAttribute('type', $this->obj);
-    }
-
-    public function setCreditCard()
-    {
-        $this->assertInstanceOf(PaymentMethod::class, $this->obj);
-    }
-
     protected function setUp()
     {
         $this->obj = new PaymentMethod();
+    }
+
+    /**
+     * @todo implement assertInstanceOf
+     */
+
+    public function testRequiredParameters()
+    {
+        $this->assertObjectHasAttribute('type', $this->obj);
     }
 }

--- a/tests/Domains/DirectPreApproval/PhoneTest.php
+++ b/tests/Domains/DirectPreApproval/PhoneTest.php
@@ -1,30 +1,25 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 13:37
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\Phone;
 
 class PhoneTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
 
+    protected function setUp()
+    {
+        $this->obj = new Phone();
+    }
+
+    /**
+     * @todo implement assertInstanceOf
+     */
+
     public function testParameters()
     {
         $this->assertObjectHasAttribute('areaCode', $this->obj);
         $this->assertObjectHasAttribute('number', $this->obj);
-    }
-
-    public function testWithParameters()
-    {
-        $this->assertInstanceOf(Phone::class, $this->obj);
-    }
-
-    protected function setUp()
-    {
-        $this->obj = new Phone();
     }
 }

--- a/tests/Domains/DirectPreApproval/PlanTest.php
+++ b/tests/Domains/DirectPreApproval/PlanTest.php
@@ -1,30 +1,23 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 13:40
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\Plan;
 
 class PlanTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
-    private $obj2;
-    private $obj3;
 
-    public function testSetPreApproval()
+    protected function setUp()
     {
-        $this->assertInstanceOf(PreApproval::class, $this->obj2);
+        $this->obj = new Plan();
     }
 
-    public function testSetReceiver()
-    {
-        $this->assertInstanceOf(Receiver::class, $this->obj3);
-    }
+    /**
+     * @todo implement assertInstanceOf
+     */
 
-    public function testParameters()
+    public function testRequiredParameters()
     {
         $this->assertObjectHasAttribute('redirectURL', $this->obj);
         $this->assertObjectHasAttribute('reference', $this->obj);
@@ -32,12 +25,5 @@ class PlanTest extends \PHPUnit_Framework_TestCase
         $this->assertObjectHasAttribute('reviewURL', $this->obj);
         $this->assertObjectHasAttribute('maxUsers', $this->obj);
         $this->assertObjectHasAttribute('receiver', $this->obj);
-    }
-
-    protected function setUp()
-    {
-        $this->obj = new Plan();
-        $this->obj2 = new PreApproval();
-        $this->obj3 = new Receiver();
     }
 }

--- a/tests/Domains/DirectPreApproval/PreApprovalTest.php
+++ b/tests/Domains/DirectPreApproval/PreApprovalTest.php
@@ -1,24 +1,30 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 13:45
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\PreApproval;
 
 class PreApprovalTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
 
-    public function testParameters()
+    protected function setUp()
+    {
+        $this->obj = new PreApproval();
+    }
+
+    /**
+     * @todo implement assertInstanceOf
+     */
+
+    public function testRequiredParameters()
     {
         $this->assertObjectHasAttribute('name', $this->obj);
         $this->assertObjectHasAttribute('charge', $this->obj);
         $this->assertObjectHasAttribute('period', $this->obj);
         $this->assertObjectHasAttribute('amountPerPayment', $this->obj);
         $this->assertObjectHasAttribute('membershipFee', $this->obj);
+        $this->assertObjectHasAttribute('trialPeriodDuration', $this->obj);
         $this->assertObjectHasAttribute('expiration', $this->obj);
         $this->assertObjectHasAttribute('details', $this->obj);
         $this->assertObjectHasAttribute('maxAmountPerPeriod', $this->obj);
@@ -31,15 +37,5 @@ class PreApprovalTest extends \PHPUnit_Framework_TestCase
         $this->assertObjectHasAttribute('dayOfMonth', $this->obj);
         $this->assertObjectHasAttribute('dayOfWeek', $this->obj);
         $this->assertObjectHasAttribute('cancelURL', $this->obj);
-    }
-
-    public function testSetExpiration()
-    {
-        $this->assertInstanceOf(Expiration::class, $this->obj->expiration);
-    }
-
-    protected function setUp()
-    {
-        $this->obj = new PreApproval();
     }
 }

--- a/tests/Domains/DirectPreApproval/ReceiverTest.php
+++ b/tests/Domains/DirectPreApproval/ReceiverTest.php
@@ -1,24 +1,24 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 13:54
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\Receiver;
 
 class ReceiverTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
 
-    public function testParameters()
-    {
-        $this->assertObjectHasAttribute('email', $this->obj);
-    }
-
     protected function setUp()
     {
         $this->obj = new Receiver();
+    }
+
+    /**
+     * @todo implements test assertInstanceOf
+     */
+
+    public function testRequiredParameters()
+    {
+        $this->assertObjectHasAttribute('email', $this->obj);
     }
 }

--- a/tests/Domains/DirectPreApproval/SenderTest.php
+++ b/tests/Domains/DirectPreApproval/SenderTest.php
@@ -1,18 +1,23 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: thiago.medeiros
- * Date: 04/08/2017
- * Time: 13:58
- */
 
-namespace PagSeguro\Domains\DirectPreApproval;
+namespace PagSeguro\Tests;
+
+use PagSeguro\Domains\DirectPreApproval\Sender;
 
 class SenderTest extends \PHPUnit_Framework_TestCase
 {
     private $obj;
 
-    public function testParameters()
+    protected function setUp()
+    {
+        $this->obj = new Sender();
+    }
+
+    /**
+     * @todo implements test assertInstanceOf
+     */
+
+    public function testRequiredParameters()
     {
         $this->assertObjectHasAttribute('name', $this->obj);
         $this->assertObjectHasAttribute('email', $this->obj);
@@ -21,10 +26,5 @@ class SenderTest extends \PHPUnit_Framework_TestCase
         $this->assertObjectHasAttribute('phone', $this->obj);
         $this->assertObjectHasAttribute('documents', $this->obj);
         $this->assertObjectHasAttribute('address', $this->obj);
-    }
-
-    protected function setUp()
-    {
-        $this->obj = new Sender();
     }
 }


### PR DESCRIPTION
### 4.2.1 (16/08/2018)
#### Correções
- **dev (testes de unidade):**
    * os quebrados foram corrigidos
    * agora estão separados em suites
    * novos casos foram implementados
    * namespace específico para testes foi adicionado "Pagseguro/Tests"
    * logs em html serão criado na pasta ignorada "tests/codeCoverage"