### PR TITLE
Correção do erro Unsupported Media Type

### DIFF
--- a/source/Resources/Http.php
+++ b/source/Resources/Http.php
@@ -210,7 +210,7 @@ class Http
     private function setHeader($charset, $contentLength)
     {
         $httpHeader = [
-            "$this->contentType charset= $charset",
+            "$this->contentType charset=$charset",
             $contentLength,
             'lib-description: php:' . Library::libraryVersion(),
             'language-engine-description: php:' . Library::phpVersion(),


### PR DESCRIPTION
Eu notei que o espaço antes de `$charset` estava ocasionado esse erro. Isso estava fazendo o Light Box não funcionar corretamente.
```
`{  
   "timestamp":"2018-08-17T20:13:10.350+0000",
   "status":415,
   "error":"Unsupported Media Type",
   "message":"Invalid mime type \"application/x-www-form-urlencoded; charset=\": 'value' must not be empty",
   "path":"/v2/checkout"
}`
```