### PR TITLE
Fix bug with No Interest Installment Quantity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     }
   ],
   "require": {
-    "php": "^5.6",
+    "php": ">=5.6",
     "ext-curl": "*",
     "lib-curl": "*",
     "lib-openssl": "*"

--- a/source/Parsers/DirectPayment/CreditCard/Installment.php
+++ b/source/Parsers/DirectPayment/CreditCard/Installment.php
@@ -53,7 +53,7 @@ trait Installment
         }
         // setNoInterestInstallmentQuantity
         if (!is_null($installment->getNoInterestInstallmentQuantity())) {
-            $data[$properties::INSTALLMENT_NO_INTEREST_INSTALLMENT_QUANTITY] = Currency::toDecimal($installment->getNoInterestInstallmentQuantity());
+            $data[$properties::INSTALLMENT_NO_INTEREST_INSTALLMENT_QUANTITY] = (int) $installment->getNoInterestInstallmentQuantity();
         }
 
         return $data;


### PR DESCRIPTION
The bug transform a value like 5 to 5.00 that causes the error:
<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?><errors><error><code>53147</code><message>no interest installment quantity invalid value: 5.00</message></error></errors>